### PR TITLE
Update redis_config.rb

### DIFF
--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -35,7 +35,7 @@ REDIS_CACHE_PARAMS = {
   url: ENV['CACHE_REDIS_URL'],
   expires_in: 10.minutes,
   namespace: cache_namespace,
-  pool_size: Sidekiq.server? ? Sidekiq.options[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
+  pool_size: Sidekiq.server? ? Sidekiq[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
   pool_timeout: 5,
   connect_timeout: 5,
 }.freeze


### PR DESCRIPTION
`config.options[:key] = value` is deprecated; this change reflects that change and stops a warning message being posted to the system log.